### PR TITLE
Table sort fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.1",
 			"devDependencies": {
 				"@onsvisual/robo-utils": "^0.3.3",
-				"@onsvisual/svelte-components": "0.1.109",
+				"@onsvisual/svelte-components": "^0.1.110",
 				"@onsvisual/svelte-maps": "^1.2.25",
 				"@playwright/test": "^1.28.1",
 				"@sveltejs/adapter-auto": "^3.0.0",
@@ -1008,9 +1008,9 @@
 			}
 		},
 		"node_modules/@onsvisual/svelte-components": {
-			"version": "0.1.109",
-			"resolved": "https://registry.npmjs.org/@onsvisual/svelte-components/-/svelte-components-0.1.109.tgz",
-			"integrity": "sha512-FfTUysNIdwYA2d1gk741ern0yKMTade7wJOQ5awt06N/yeJ0JtUuZqh8PfPGcWp6ZZp05zFChVIxsmR921XcqQ==",
+			"version": "0.1.110",
+			"resolved": "https://registry.npmjs.org/@onsvisual/svelte-components/-/svelte-components-0.1.110.tgz",
+			"integrity": "sha512-JLqHwxQ+Kv0fpk8YTf3efzQc+s/ul6ne11ETI2T6dIVseOgkqA+DP1EgTUV+SvUcnuuFKfoliB+cD2RqlH90dg==",
 			"dev": true,
 			"dependencies": {
 				"@fortawesome/free-brands-svg-icons": "^5.15.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@onsvisual/robo-utils": "^0.3.3",
-		"@onsvisual/svelte-components": "0.1.109",
+		"@onsvisual/svelte-components": "^0.1.110",
 		"@onsvisual/svelte-maps": "^1.2.25",
 		"@playwright/test": "^1.28.1",
 		"@sveltejs/adapter-auto": "^3.0.0",


### PR DESCRIPTION
This PR is to fix sorting of tables with null values and values of mixed types. See issue #28.

To test this fix, open an indicator like **Economic inactivity rate (Great Britain)** and try to sort a column that includes null values (displayed as "-"). The nulls should sort to the bottom for both ascending and descending sort.