### PR TITLE
Restore custom logging

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,5 @@
-import type { Handle, HandleServerError } from '@sveltejs/kit';
+// import type { Handle, HandleServerError } from '@sveltejs/kit';
+import type { Handle } from '@sveltejs/kit';
 import logger from '$lib/logger';
 
 // hook up the logger
@@ -20,9 +21,10 @@ export const handle: Handle = async ({ event, resolve }) => {
 	return response;
 };
 
-export const handleError: HandleServerError = async ({ status }) => {
-	return {
-		message: status === 404 ? "Page not found" : 'Sorry, there is a problem with the service',
-		errorId: status || 500
-	};
-};
+// TODO: this breaks the custom logger
+// export const handleError: HandleServerError = async ({ status }) => {
+// 	return {
+// 		message: status === 404 ? "Page not found" : 'Sorry, there is a problem with the service',
+// 		errorId: status || 500
+// 	};
+// };


### PR DESCRIPTION
Comment-out `handleError` hook which breaks the custom Node logger