### PR TITLE
Beeswarm toggle

### DIFF
--- a/src/lib/components/modals/OptionsModal.svelte
+++ b/src/lib/components/modals/OptionsModal.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { Checkbox } from '@onsvisual/svelte-components';
+	import { Checkbox, ButtonGroup, ButtonGroupItem } from '@onsvisual/svelte-components';
 	import Modal from './Modal.svelte';
 	import RangeSlider from './RangeSlider.svelte';
 	import { cloneState } from './modalHelpers';
 
-	let { data, pageState = $bindable(), hasIntervals = true } = $props();
+	let { data, pageState = $bindable(), hasIntervals = true, mode = 'default' } = $props();
 
 	let _pageState = $state(cloneState(pageState));
 	let formatTick = $derived(pageState?.formatPeriod?.() || ((d) => d));
@@ -35,4 +35,31 @@
 	{#if !hasIntervals}
 		<p class="ons-chart__caption">Note: Confidence intervals not available for this indicator</p>
 	{/if}
+
+	{#if mode === 'default'}
+		<div class="mobile-only">
+			<ButtonGroup
+				name="primary"
+				legend="Choose a chart type"
+				value="beeswarm"
+				visuallyHideLegend
+				bind:selectedChartType={_pageState.selectedChartType}
+			>
+				<ButtonGroupItem value="beeswarm" label="Beeswarm" />
+				<ButtonGroupItem value="line" label="Line chart" />
+			</ButtonGroup>
+		</div>
+	{/if}
 </Modal>
+
+<style>
+	.mobile-only {
+		display: block;
+	}
+
+	@media (min-width: 768px) {
+		.mobile-only {
+			display: none;
+		}
+	}
+</style>

--- a/src/lib/components/modals/OptionsModal.svelte
+++ b/src/lib/components/modals/OptionsModal.svelte
@@ -41,12 +41,11 @@
 			<ButtonGroup
 				name="primary"
 				legend="Choose a chart type"
-				value="beeswarm"
 				visuallyHideLegend
-				bind:selectedChartType={_pageState.selectedChartType}
+				bind:value={_pageState.selectedChartType}
 			>
 				<ButtonGroupItem value="beeswarm" label="Beeswarm" />
-				<ButtonGroupItem value="line" label="Line chart" />
+				<ButtonGroupItem value="sparkline" label="Line chart" />
 			</ButtonGroup>
 		</div>
 	{/if}

--- a/src/routes/(app)/areas/[code]/indicators/+page.svelte
+++ b/src/routes/(app)/areas/[code]/indicators/+page.svelte
@@ -45,7 +45,8 @@
 			selectedGeoGroup: data.geoGroups[0],
 			selectedPeriodRange: [data.periods[0], data.periods[data.periods.length - 1]],
 			selectedCluster: data?.related?.similar?.[0],
-			showConfidenceIntervals: false
+			showConfidenceIntervals: false,
+			selectedChartType: 'beeswarm'
 		};
 	}
 
@@ -131,11 +132,13 @@
 {#snippet indicator(item, topic)}
 	{@const hidden = hiddenTopics[topic.slug] && item.index >= maxIndicators}
 	{#if item.heading}<h4 id={item.headingSlug}>{item.heading}</h4>{/if}
+
 	<IndicatorRow
 		indicator={item.slug}
 		metadata={data.metadata[item.slug]}
 		timeRange={pageState.selectedPeriodRange}
 		showIntervals={pageState.showConfidenceIntervals}
+		selectedChart={pageState.selectedChartType}
 		selected={[areaProps.areacd, ...pageState.selectedAreas.map((a) => a.areacd)]}
 		geoGroup={pageState.selectedGeoGroup}
 		{hidden}

--- a/src/routes/(app)/areas/[code]/indicators/IndicatorRow.svelte
+++ b/src/routes/(app)/areas/[code]/indicators/IndicatorRow.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { resolve } from '$app/paths';
 	import { Observe, Em, ButtonGroup, ButtonGroupItem, Icon } from '@onsvisual/svelte-components';
 	import { makeDataUrl, makeValueFormatter, makePeriodFormatter, downloadEvent } from '$lib/utils';
@@ -13,11 +14,20 @@
 		metadata,
 		timeRange,
 		showIntervals = false,
+		selectedChart = 'beeswarm',
 		selected = [],
 		geoGroup,
 		hovered = $bindable(),
 		hidden = null
 	} = $props();
+
+	let isMobile = $state(false);
+
+	onMount(() => {
+		const mq = window.matchMedia('(max-width: 767px)');
+		isMobile = mq.matches;
+		mq.addEventListener('change', (e) => (isMobile = e.matches));
+	});
 
 	let visible = $state(false);
 	let expanded = $state(false);
@@ -180,49 +190,54 @@
 			</div>
 		{:else}
 			<div class="indicator-charts">
-				<div class="indicator-beeswarm">
-					<ChartDataLoader
-						id="{indicator} beeswarm"
-						dataUrl={dataUrl['beeswarm']}
-						noDataMessage="Chart data not available."
-						{visible}
-					>
-						{#snippet chart(data)}
-							<Beeswarm
-								{data}
-								{metadata}
-								{formatPeriod}
-								{formatValue}
-								valuePrefix={metadata.prefix}
-								valueSuffix={metadata.suffix}
-								{showIntervals}
-								{selected}
-								bind:hovered
-							/>
-						{/snippet}
-					</ChartDataLoader>
-				</div>
-				<div class="indicator-sparkline">
-					<ChartDataLoader
-						id="{indicator} sparkline"
-						dataUrl={dataUrl['sparkline']}
-						noDataMessage="Time series data not available."
-						{visible}
-					>
-						{#snippet chart(data)}
-							<Sparkline
-								{data}
-								{metadata}
-								{formatPeriod}
-								{formatValue}
-								valuePrefix={metadata.prefix}
-								valueSuffix={metadata.suffix}
-								{showIntervals}
-								{selected}
-							/>
-						{/snippet}
-					</ChartDataLoader>
-				</div>
+				{#if !isMobile || selectedChart === 'beeswarm'}
+					<div class="indicator-beeswarm">
+						<ChartDataLoader
+							id="{indicator} beeswarm"
+							dataUrl={dataUrl['beeswarm']}
+							noDataMessage="Chart data not available."
+							{visible}
+						>
+							{#snippet chart(data)}
+								<Beeswarm
+									{data}
+									{metadata}
+									{formatPeriod}
+									{formatValue}
+									valuePrefix={metadata.prefix}
+									valueSuffix={metadata.suffix}
+									{showIntervals}
+									{selected}
+									bind:hovered
+								/>
+							{/snippet}
+						</ChartDataLoader>
+					</div>
+				{/if}
+
+				{#if !isMobile || selectedChart === 'sparkline'}
+					<div class="indicator-sparkline">
+						<ChartDataLoader
+							id="{indicator} sparkline"
+							dataUrl={dataUrl['sparkline']}
+							noDataMessage="Time series data not available."
+							{visible}
+						>
+							{#snippet chart(data)}
+								<Sparkline
+									{data}
+									{metadata}
+									{formatPeriod}
+									{formatValue}
+									valuePrefix={metadata.prefix}
+									valueSuffix={metadata.suffix}
+									{showIntervals}
+									{selected}
+								/>
+							{/snippet}
+						</ChartDataLoader>
+					</div>
+				{/if}
 			</div>
 		{/if}
 	</div>
@@ -249,11 +264,20 @@
 	}
 	.indicator-beeswarm {
 		flex-grow: 1;
-		max-width: 470px;
+		max-width: 350px;
 	}
 	.indicator-sparkline {
 		flex-shrink: 1;
-		width: 200px;
+		width: 300px;
+	}
+
+	@media (min-width: 768px) {
+		.indicator-beeswarm {
+			max-width: 470px;
+		}
+		.indicator-sparkline {
+			width: 200px;
+		}
 	}
 	.indicator-row :global(svg) {
 		overflow: visible;


### PR DESCRIPTION
* Adds toggle to chart options modal (on mobile only) to choose between Beeswarm and Sparkline
* Connects whether charts show to toggle

Couple of things to consider
* Technically, if a user was on mobile, selected line chart, then switched to desktop, then the current implementation wouldn't switch it back to beeswarm. However, I think this is a very unlikely user journey.
* The labels on the chart toggle are currently "Beeswarm" and "line chart". I don't know if there's a better option than "Beeswarm" since I don't think many people will know what they are?