### PR TITLE
V2 updates/diverging palette

### DIFF
--- a/src/lib/components/charts/Map.svelte
+++ b/src/lib/components/charts/Map.svelte
@@ -4,7 +4,7 @@
 	import bbox from '@turf/bbox';
 	import { parseData, getMapFeatures, getGeoYear, valuesToBreaks } from '$lib/utils';
 	import { getPaletteColor } from './chartHelpers';
-	import { ukBounds, ONScolours } from '$lib/config';
+	import { ukBounds, ONScolours, mapPaletteSequential, mapPaletteDivering } from '$lib/config';
 	import { geoYearFilter } from '$lib/api/geo/helpers/geoFilters';
 	import { Map, MapSource, MapLayer, MapTooltip } from '@onsvisual/svelte-maps';
 	import MapLegend from './MapLegend.svelte';
@@ -18,13 +18,6 @@
 		formatValue = (d) => d,
 		formatPeriod = (d) => d,
 		geoLevel = null,
-		colors = [
-			'rgb(234, 236, 177)',
-			'rgb(169, 216, 145)',
-			'rgb(0, 167, 186)',
-			'rgb(0, 78, 166)',
-			'rgb(0, 13, 84)'
-		],
 		extendHeight = null
 	} = $props();
 
@@ -33,6 +26,7 @@
 
 	let map = $state();
 	let features = $state.raw();
+	let valuesDiverge = $derived(_data.some((d) => d.value < 0) && _data.some((d) => d.value > 0));
 	let _data = $derived(parseData(data));
 	let geoYear = $derived(getGeoYear(data.areacd));
 	let breaks = $derived(
@@ -42,6 +36,50 @@
 		)
 	);
 	let height = $derived(500 + (extendHeight ?? 0));
+
+	const NEG_RAMP = ['#CE321FCC', '#F09977CC'];
+	const NEUTRAL = '#FEF4D7cc';
+	const POS_RAMP = ['#96B3B3cc', '#007590cc'];
+
+	function pickRamp(ramp: string[], n: number): string[] {
+		if (n === 1) return [ramp[Math.floor(ramp.length / 2)]];
+		const step = (ramp.length - 1) / (n - 1);
+		return Array.from({ length: n }, (_, i) => ramp[Math.round(i * step)]);
+	}
+
+	function buildDivergingColors(breaks: number[]): string[] {
+		const bins = breaks.length - 1;
+
+		const zeroBreakIndex = breaks.indexOf(0);
+
+		if (zeroBreakIndex !== -1) {
+			const negBins = zeroBreakIndex;
+			const posBins = bins - zeroBreakIndex;
+
+			const negColors = pickRamp(NEG_RAMP, negBins);
+			const posColors = pickRamp(POS_RAMP, posBins);
+
+			return [...negColors, ...posColors];
+		}
+
+		let zeroBinIndex = -1;
+		for (let i = 0; i < bins; i++) {
+			if (breaks[i] < 0 && breaks[i + 1] > 0) {
+				zeroBinIndex = i;
+				break;
+			}
+		}
+
+		const negBins = zeroBinIndex;
+		const posBins = bins - zeroBinIndex - 1;
+
+		const negColors = pickRamp(NEG_RAMP, negBins);
+		const posColors = pickRamp(POS_RAMP, posBins);
+
+		return [...negColors, NEUTRAL, ...posColors];
+	}
+
+	let colors = $derived(valuesDiverge ? buildDivergingColors(breaks) : mapPaletteSequential);
 
 	function doHover(e) {
 		const area = e.detail?.feature?.properties || e.detail?.d;
@@ -117,6 +155,8 @@
 	$effect(() => fitBounds(bounds));
 
 	onMount(async () => (features = await getMapFeatures()));
+
+	$inspect(breaks);
 </script>
 
 <p class="ons-u-vh">Map of {metadata.label}. The data is available to download below.</p>
@@ -223,6 +263,7 @@
 		prefix={metadata.prefix}
 		suffix={metadata.suffix}
 		format={formatValue}
+		{colors}
 	/>
 </div>
 

--- a/src/lib/components/charts/Map.svelte
+++ b/src/lib/components/charts/Map.svelte
@@ -33,7 +33,7 @@
 
 	let map = $state();
 	let features = $state.raw();
-	let valuesDiverge = $derived(_data.some((d) => d.value < 0) && _data.some((d) => d.value > 0));
+	let valuesDiverge = $derived(metadata.canBeNegative);
 	let _data = $derived(parseData(data));
 	let geoYear = $derived(getGeoYear(data.areacd));
 	let breaks = $derived(
@@ -45,6 +45,8 @@
 	let height = $derived(500 + (extendHeight ?? 0));
 
 	function pickColours(ramp, n) {
+		if (n === 1) return [ramp[Math.floor(ramp.length / 2)]];
+
 		const step = (ramp.length - 1) / (n - 1);
 		return Array.from({ length: n }, (_, i) => ramp[Math.round(i * step)]);
 	}

--- a/src/lib/components/charts/Map.svelte
+++ b/src/lib/components/charts/Map.svelte
@@ -8,9 +8,8 @@
 		ukBounds,
 		ONScolours,
 		mapPaletteSequential,
-		negative_cols,
-		positive_cols,
-		neutral_col
+		mapPaletteDivergingNoNeutral,
+		mapPaletteDivergingNeutral
 	} from '$lib/config';
 	import { geoYearFilter } from '$lib/api/geo/helpers/geoFilters';
 	import { Map, MapSource, MapLayer, MapTooltip } from '@onsvisual/svelte-maps';
@@ -44,27 +43,10 @@
 	);
 	let height = $derived(500 + (extendHeight ?? 0));
 
-	function pickColours(ramp, n) {
-		if (n === 1) return [ramp[Math.floor(ramp.length / 2)]];
-
-		const step = (ramp.length - 1) / (n - 1);
-		return Array.from({ length: n }, (_, i) => ramp[Math.round(i * step)]);
-	}
-
 	function buildDivergingColors(breaks) {
 		const bins = breaks.length - 1;
 
-		const zeroBreakIndex = breaks.indexOf(0);
-
-		if (zeroBreakIndex !== -1) {
-			const nNegBins = zeroBreakIndex;
-			const nPosBins = bins - zeroBreakIndex;
-
-			const negColors = pickColours(negative_cols, nNegBins);
-			const posColors = pickColours(positive_cols, nPosBins);
-
-			return [...negColors, ...posColors];
-		}
+		const zeroBreakIndex = breaks.includes(0);
 
 		let zeroBinIndex = -1;
 		for (let i = 0; i < bins; i++) {
@@ -74,13 +56,14 @@
 			}
 		}
 
-		const nNegBins = zeroBinIndex;
-		const nPosBins = bins - zeroBinIndex - 1;
+		let colors = zeroBreakIndex ? mapPaletteDivergingNoNeutral : mapPaletteDivergingNeutral;
+		let neutralIndex = Math.floor(colors.length / 2);
+		let c2 = colors.slice(
+			neutralIndex - zeroBinIndex,
+			mapPaletteDivergingNeutral.length - zeroBinIndex
+		);
 
-		const negColors = pickColours(negative_cols, nNegBins);
-		const posColors = pickColours(positive_cols, nPosBins);
-
-		return [...negColors, neutral_col, ...posColors];
+		return [...c2];
 	}
 
 	let colors = $derived(valuesDiverge ? buildDivergingColors(breaks) : mapPaletteSequential);

--- a/src/lib/components/charts/Map.svelte
+++ b/src/lib/components/charts/Map.svelte
@@ -4,13 +4,7 @@
 	import bbox from '@turf/bbox';
 	import { parseData, getMapFeatures, getGeoYear, valuesToBreaks } from '$lib/utils';
 	import { getPaletteColor } from './chartHelpers';
-	import {
-		ukBounds,
-		ONScolours,
-		mapPaletteSequential,
-		mapPaletteDivergingNoNeutral,
-		mapPaletteDivergingNeutral
-	} from '$lib/config';
+	import { ukBounds, ONScolours, mapPaletteSequential, mapPaletteDiverging } from '$lib/config';
 	import { geoYearFilter } from '$lib/api/geo/helpers/geoFilters';
 	import { Map, MapSource, MapLayer, MapTooltip } from '@onsvisual/svelte-maps';
 	import MapLegend from './MapLegend.svelte';
@@ -44,24 +38,40 @@
 	let height = $derived(500 + (extendHeight ?? 0));
 
 	function buildDivergingColors(breaks) {
-		const bins = breaks.length - 1;
+		const nBins = breaks.length - 1;
+		console.log({ nBins });
 
-		const zeroBreakIndex = breaks.includes(0);
+		const zeroBreakExists = breaks.includes(0);
 
-		let zeroBinIndex = -1;
-		for (let i = 0; i < bins; i++) {
-			if (breaks[i] < 0 && breaks[i + 1] > 0) {
-				zeroBinIndex = i;
-				break;
+		let zeroBinIndex;
+		if (zeroBreakExists) {
+			zeroBinIndex = breaks.indexOf(0);
+		} else {
+			zeroBinIndex = -1;
+			for (let i = 0; i < nBins; i++) {
+				if (breaks[i] < 0 && breaks[i + 1] > 0) {
+					zeroBinIndex = i;
+					break;
+				}
 			}
 		}
 
-		let colors = zeroBreakIndex ? mapPaletteDivergingNoNeutral : mapPaletteDivergingNeutral;
-		let neutralIndex = Math.floor(colors.length / 2);
-		let c2 = colors.slice(
-			neutralIndex - zeroBinIndex,
-			mapPaletteDivergingNeutral.length - zeroBinIndex
-		);
+		const nPosBins = zeroBreakExists ? nBins - zeroBinIndex : nBins - zeroBinIndex - 1;
+		const nNegBins = zeroBreakExists ? nBins - nPosBins : nBins - nPosBins - 1;
+
+		const paletteSize = zeroBreakExists
+			? Math.min(9, Math.max(nPosBins, nNegBins) * 2)
+			: Math.min(9, Math.max(nPosBins, nNegBins) * 2 + 1);
+
+		const colors = mapPaletteDiverging[paletteSize];
+
+		const neutralIndex =
+			// force neutral colour to be used as positive or negative when all values are pos or neg
+			// (means we can use 9 colour palette instead of going up to 11 when there are five breaks above/below 0)
+			zeroBinIndex == -1 ? Math.floor(colors.length / 2) - 1 : Math.floor(colors.length / 2);
+		const c2 = zeroBreakExists
+			? colors.slice(neutralIndex - zeroBinIndex, colors.length - zeroBinIndex)
+			: colors.slice(neutralIndex - zeroBinIndex, colors.length - zeroBinIndex + 1);
 
 		return [...c2];
 	}
@@ -142,8 +152,6 @@
 	$effect(() => fitBounds(bounds));
 
 	onMount(async () => (features = await getMapFeatures()));
-
-	$inspect(breaks);
 </script>
 
 <p class="ons-u-vh">Map of {metadata.label}. The data is available to download below.</p>

--- a/src/lib/components/charts/Map.svelte
+++ b/src/lib/components/charts/Map.svelte
@@ -4,7 +4,14 @@
 	import bbox from '@turf/bbox';
 	import { parseData, getMapFeatures, getGeoYear, valuesToBreaks } from '$lib/utils';
 	import { getPaletteColor } from './chartHelpers';
-	import { ukBounds, ONScolours, mapPaletteSequential, mapPaletteDivering } from '$lib/config';
+	import {
+		ukBounds,
+		ONScolours,
+		mapPaletteSequential,
+		negative_cols,
+		positive_cols,
+		neutral_col
+	} from '$lib/config';
 	import { geoYearFilter } from '$lib/api/geo/helpers/geoFilters';
 	import { Map, MapSource, MapLayer, MapTooltip } from '@onsvisual/svelte-maps';
 	import MapLegend from './MapLegend.svelte';
@@ -37,27 +44,22 @@
 	);
 	let height = $derived(500 + (extendHeight ?? 0));
 
-	const NEG_RAMP = ['#CE321FCC', '#F09977CC'];
-	const NEUTRAL = '#FEF4D7cc';
-	const POS_RAMP = ['#96B3B3cc', '#007590cc'];
-
-	function pickRamp(ramp: string[], n: number): string[] {
-		if (n === 1) return [ramp[Math.floor(ramp.length / 2)]];
+	function pickColours(ramp, n) {
 		const step = (ramp.length - 1) / (n - 1);
 		return Array.from({ length: n }, (_, i) => ramp[Math.round(i * step)]);
 	}
 
-	function buildDivergingColors(breaks: number[]): string[] {
+	function buildDivergingColors(breaks) {
 		const bins = breaks.length - 1;
 
 		const zeroBreakIndex = breaks.indexOf(0);
 
 		if (zeroBreakIndex !== -1) {
-			const negBins = zeroBreakIndex;
-			const posBins = bins - zeroBreakIndex;
+			const nNegBins = zeroBreakIndex;
+			const nPosBins = bins - zeroBreakIndex;
 
-			const negColors = pickRamp(NEG_RAMP, negBins);
-			const posColors = pickRamp(POS_RAMP, posBins);
+			const negColors = pickColours(negative_cols, nNegBins);
+			const posColors = pickColours(positive_cols, nPosBins);
 
 			return [...negColors, ...posColors];
 		}
@@ -70,13 +72,13 @@
 			}
 		}
 
-		const negBins = zeroBinIndex;
-		const posBins = bins - zeroBinIndex - 1;
+		const nNegBins = zeroBinIndex;
+		const nPosBins = bins - zeroBinIndex - 1;
 
-		const negColors = pickRamp(NEG_RAMP, negBins);
-		const posColors = pickRamp(POS_RAMP, posBins);
+		const negColors = pickColours(negative_cols, nNegBins);
+		const posColors = pickColours(positive_cols, nPosBins);
 
-		return [...negColors, NEUTRAL, ...posColors];
+		return [...negColors, neutral_col, ...posColors];
 	}
 
 	let colors = $derived(valuesDiverge ? buildDivergingColors(breaks) : mapPaletteSequential);

--- a/src/lib/components/charts/MapLegend.svelte
+++ b/src/lib/components/charts/MapLegend.svelte
@@ -10,13 +10,7 @@
 		barHeight = 15,
 		labelHeight = 20,
 		breaks,
-		colors = [
-			'rgba(234,236,177,.8)',
-			'rgba(169,216,145,.8)',
-			'rgba(0,167,186,.8)',
-			'rgba(0,78,166,.8)',
-			'rgba(0,13,84,.8)'
-		],
+		colors,
 		format = (d) => d,
 		prefix = '',
 		suffix = '',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -108,31 +108,23 @@ export const extremeAreas = {
 
 export const mobileBreakpoint = 510;
 
-export const mapPaletteDivergingNeutral = [
-	'#ce321f',
-	'#de6041',
-	'#eb8665',
-	'#f5ab89',
-	'#fbd0af',
-	'#fef4d7',
-	'#d5d9c9',
-	'#abbfbb',
-	'#81a6ac',
-	'#538d9e',
-	'#007590'
-];
-export const mapPaletteDivergingNoNeutral = [
-	'#ce321f',
-	'#de6041',
-	'#eb8665',
-	'#f5ab89',
-	'#fbd0af',
-	'#d5d9c9',
-	'#abbfbb',
-	'#81a6ac',
-	'#538d9e',
-	'#007590'
-];
+export const mapPaletteDiverging = {
+	5: ['#ce321f', '#f09977', '#fef4d7', '#96b3b3', '#007590'],
+	6: ['#ce321f', '#e77a59', '#f7b796', '#b9c8bf', '#729ea8', '#007590'],
+	7: ['#ce321f', '#e77a59', '#f7b796', '#fef4d7', '#b9c8bf', '#729ea8', '#007590'],
+	8: ['#ce321f', '#e16a4a', '#f09977', '#fac6a6', '#cad3c5', '#96b3b3', '#5f93a2', '#007590'],
+	9: [
+		'#ce321f',
+		'#e16a4a',
+		'#f09977',
+		'#fac6a6',
+		'#fef4d7',
+		'#cad3c5',
+		'#96b3b3',
+		'#5f93a2',
+		'#007590'
+	]
+};
 
 export const mapPaletteSequential = [
 	'#eaecb1cc',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -108,20 +108,6 @@ export const extremeAreas = {
 
 export const mobileBreakpoint = 510;
 
-// export const mapPaletteDivering = [
-// 	'#CE321FCC',
-// 	'#E16A4Acc',
-// 	'#F09977CC',
-// 	'#FAC6A6CC',
-// 	'#FEF4D7CC',
-// 	'#CAD3C5CC',
-// 	'#96B3B3CC',
-// 	'#5F93A2CC',
-// 	'#007590CC'
-// ];
-
-export const mapPaletteDivering = ['#CE321Fcc', '#F09977cc', '#FEF4D7cc', '#96B3B3cc', '#007590cc'];
-
 export const negative_cols = ['#CE321FCC', '#E16A4Acc', '#F09977CC', '#FAC6A6'];
 export const neutral_col = '#FEF4D7cc';
 export const positive_cols = ['#CAD3C5cc', '#96B3B3cc', '#5F93A2cc', '#007590cc'];

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -122,6 +122,10 @@ export const mobileBreakpoint = 510;
 
 export const mapPaletteDivering = ['#CE321Fcc', '#F09977cc', '#FEF4D7cc', '#96B3B3cc', '#007590cc'];
 
+export const negative_cols = ['#CE321FCC', '#E16A4Acc', '#F09977CC', '#FAC6A6'];
+export const neutral_col = '#FEF4D7cc';
+export const positive_cols = ['#CAD3C5cc', '#96B3B3cc', '#5F93A2cc', '#007590cc'];
+
 export const mapPaletteSequential = [
 	'#eaecb1cc',
 	'#a9d891cc',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -108,9 +108,31 @@ export const extremeAreas = {
 
 export const mobileBreakpoint = 510;
 
-export const negative_cols = ['#CE321FCC', '#E16A4Acc', '#F09977CC', '#FAC6A6'];
-export const neutral_col = '#FEF4D7cc';
-export const positive_cols = ['#CAD3C5cc', '#96B3B3cc', '#5F93A2cc', '#007590cc'];
+export const mapPaletteDivergingNeutral = [
+	'#ce321f',
+	'#de6041',
+	'#eb8665',
+	'#f5ab89',
+	'#fbd0af',
+	'#fef4d7',
+	'#d5d9c9',
+	'#abbfbb',
+	'#81a6ac',
+	'#538d9e',
+	'#007590'
+];
+export const mapPaletteDivergingNoNeutral = [
+	'#ce321f',
+	'#de6041',
+	'#eb8665',
+	'#f5ab89',
+	'#fbd0af',
+	'#d5d9c9',
+	'#abbfbb',
+	'#81a6ac',
+	'#538d9e',
+	'#007590'
+];
 
 export const mapPaletteSequential = [
 	'#eaecb1cc',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -107,3 +107,25 @@ export const extremeAreas = {
 };
 
 export const mobileBreakpoint = 510;
+
+// export const mapPaletteDivering = [
+// 	'#CE321FCC',
+// 	'#E16A4Acc',
+// 	'#F09977CC',
+// 	'#FAC6A6CC',
+// 	'#FEF4D7CC',
+// 	'#CAD3C5CC',
+// 	'#96B3B3CC',
+// 	'#5F93A2CC',
+// 	'#007590CC'
+// ];
+
+export const mapPaletteDivering = ['#CE321Fcc', '#F09977cc', '#FEF4D7cc', '#96B3B3cc', '#007590cc'];
+
+export const mapPaletteSequential = [
+	'#eaecb1cc',
+	'#a9d891cc',
+	'#00a7bacc',
+	'#004ea6cc',
+	'#000d54cc'
+];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -186,34 +186,6 @@ export function valuesToBreaks(values: number[], dp = 0, count = 5) {
 	); // de-duplicate and round breaks
 }
 
-// export function divergingBreaks(values: number[], dp = 0, count = 6) {
-// 	if (!values.length) return [];
-
-// 	const clusters = ckmeans(values, values.length < count ? values.length : count);
-
-// 	let breaks = [
-// 		...clusters.map((c) => c[0]),
-// 		clusters[clusters.length - 1][clusters[clusters.length - 1].length - 1]
-// 	];
-
-// 	const minVal = Math.min(...values);
-// 	const maxVal = Math.max(...values);
-// 	const extent = Math.max(Math.abs(minVal), Math.abs(maxVal));
-
-// 	// Rescale breaks
-// 	const scaled = breaks.map((b) => {
-// 		return (b / (b < 0 ? Math.abs(minVal) : maxVal)) * extent;
-// 	});
-
-// 	return Array.from(
-// 		new Set(
-// 			scaled.map((d, i) =>
-// 				round(d, dp, i === 0 ? 'floor' : i === scaled.length - 1 ? 'ceil' : 'round')
-// 			)
-// 		)
-// 	);
-// }
-
 export function getAreaType(area: areaObject) {
 	return geoLevelsAllLookup[area.areacd?.slice?.(0, 3)]?.label || null;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -186,6 +186,34 @@ export function valuesToBreaks(values: number[], dp = 0, count = 5) {
 	); // de-duplicate and round breaks
 }
 
+// export function divergingBreaks(values: number[], dp = 0, count = 6) {
+// 	if (!values.length) return [];
+
+// 	const clusters = ckmeans(values, values.length < count ? values.length : count);
+
+// 	let breaks = [
+// 		...clusters.map((c) => c[0]),
+// 		clusters[clusters.length - 1][clusters[clusters.length - 1].length - 1]
+// 	];
+
+// 	const minVal = Math.min(...values);
+// 	const maxVal = Math.max(...values);
+// 	const extent = Math.max(Math.abs(minVal), Math.abs(maxVal));
+
+// 	// Rescale breaks
+// 	const scaled = breaks.map((b) => {
+// 		return (b / (b < 0 ? Math.abs(minVal) : maxVal)) * extent;
+// 	});
+
+// 	return Array.from(
+// 		new Set(
+// 			scaled.map((d, i) =>
+// 				round(d, dp, i === 0 ? 'floor' : i === scaled.length - 1 ? 'ceil' : 'round')
+// 			)
+// 		)
+// 	);
+// }
+
 export function getAreaType(area: areaObject) {
 	return geoLevelsAllLookup[area.areacd?.slice?.(0, 3)]?.label || null;
 }


### PR DESCRIPTION
implements diverging map palette when indicator values include both positive and negative values - determined by metatdata.canBeNegative, e.g.: 

- five-year-population-change
- net-additions-housing-stock

Palette length is scaled to max number of bins around zero