### PR TITLE
Don't run npm install in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,6 @@ test-component:
 
 .PHONY: build-builder-init
 build-builder-init:
-	$(NPM) install
 	$(NPM) ci
 
 .PHONY: build-builder


### PR DESCRIPTION
Remove redundant `npm install` in Makefile to resolve lock file bug in CI. 

`npm install` does extra work that `npm ci` immediately undoes. Worse, if npm install resolved something differently to the lock file, `npm ci` fails.